### PR TITLE
Enable Google Analytics on Try Zeek

### DIFF
--- a/manager/web-ui/public/index.html
+++ b/manager/web-ui/public/index.html
@@ -13,6 +13,17 @@
       work correctly both with client-side routing and a non-root public URL.
       Learn how to configure a non-root public URL by running `npm run build`.
     -->
+
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-144186885-1"></script>
+    <script>
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+
+      gtag('config', 'UA-144186885-1');
+    </script>
+
     <title>Try Zeek</title>
   </head>
   <body>


### PR DESCRIPTION
This enables Google Analytics on Try Zeek for better data on who is using the tutorial.