### PR TITLE
Change links from www/sphinx to RTD.

### DIFF
--- a/manager/static/examples/basics/event/readme.markdown
+++ b/manager/static/examples/basics/event/readme.markdown
@@ -19,8 +19,8 @@ They differ from functions in the following ways:
   `&priority`.
 
 In the Zeek documentation, there is a detailed chapter about Zeek's event engine, how Zeek and the scripts
-interact, and what role the `event` plays in a Zeek script. Please [read](https://www.zeek.org/sphinx-git/scripting/index.html#the-event-queue-and-event-handlers).
-A reference for predefined events not related to protocol or file analysis is [here](https://www.zeek.org/sphinx/scripts/base/bif/event.bif.bro.html).
+interact, and what role the `event` plays in a Zeek script. Please [read](https://docs.zeek.org/en/current/scripting/index.html#the-event-queue-and-event-handlers).
+A reference for predefined events not related to protocol or file analysis is [here](https://docs.zeek.org/en/current/scripts/base/bif/event.bif.bro.html).
 
 This example shows how to define and trigger a custom event.
 

--- a/manager/static/examples/basics/exercise2/solution-script-exercise-2/readme.markdown
+++ b/manager/static/examples/basics/exercise2/solution-script-exercise-2/readme.markdown
@@ -8,17 +8,17 @@ The solution is one possible way to solve this exercise.
 
 * First we write local subnets into a set.
 * To count all connections we declare the global counter my\_count.
-* To learn about every new connection we simply use the event [new\_connection](https://www.zeek.org/sphinx/scripts/base/bif/event.bif.bro.html#id-new_connection). 
+* To learn about every new connection we simply use the event [new\_connection](https://docs.zeek.org/en/current/scripts/base/bif/event.bif.bro.html#id-new_connection). 
   Every time this
   event is triggered we increase the counter. For the first 10 connections we print source IP and port and 
   destination IP and port, plus connection ID and time. To get the connection ID we need the filed uid of the connection.
-  To print the start time of the connection in human readable form we use the Zeek bif [strftime](https://www.zeek.org/sphinx/scripts/base/bif/bro.bif.bro.html?highlight=strftime#id-strftime).
+  To print the start time of the connection in human readable form we use the Zeek bif [strftime](https://docs.zeek.org/en/current/scripts/base/bif/bro.bif.bro.html?highlight=strftime#id-strftime).
 * The duration of a connection - expressed as an interval - can be retrieved when the connection ends. 
-  The event [connection\_state\_remove](https://www.zeek.org/sphinx/scripts/base/bif/event.bif.bro.html?highlight=connection_state_remove#id-connection_state_remove)
+  The event [connection\_state\_remove](https://docs.zeek.org/en/current/scripts/base/bif/event.bif.bro.html?highlight=connection_state_remove#id-connection_state_remove)
   is triggered when a connection is about to be removed from memory. Then we can simply ask for the duration.
 * At the very end inside the bro\_done event we compute the rest. Print the number of connections stored in my\_count
   and use a for-loop to print out a list of all unique IPs and if they are local or external IPs.
   In this example we simply define which subnets are considered local. This does not mean that the list is complete. In a real
-  world example this should be verified and documented in [networks.cfg](https://www.zeek.org/sphinx/components/broctl/README.html).
+  world example this should be verified and documented in [networks.cfg](https://docs.zeek.org/en/current/components/broctl/README.html).
 
 

--- a/manager/static/examples/basics/functions/readme.markdown
+++ b/manager/static/examples/basics/functions/readme.markdown
@@ -19,7 +19,7 @@ Input parameters are specified within parentheses in a comma separated list. The
 All parameters in this function are of type 'string'. We will see more about types in Zeek in the next 
 [lesson](http://try.zeek.org/example/primitive_datatypes).
 
-The second argument in this example is optional. This is because of the [attribute](https://www.zeek.org/sphinx/script-reference/attributes.html) 
+The second argument in this example is optional. This is because of the [attribute](https://docs.zeek.org/en/current/script-reference/attributes.html) 
 &default. In the example here the default value would be '\*' in case the second parameter is missing.
 
 Another element seen here is the '+'-operator that concatenates the strings in this case.

--- a/manager/static/examples/basics/loading/readme.markdown
+++ b/manager/static/examples/basics/loading/readme.markdown
@@ -7,7 +7,7 @@ Loading Scripts
 Like most programming languages, Zeek has the ability to load in script code 
 from other files.  There is a directive, `@load` which provides the capability.
 
-The code here shows a simple script that does nothing but loading a script. The script [misc/dump-events](https://www.zeek.org/sphinx/scripts/policy/misc/dump-events.bro.html) prints the events that Zeek generates out to standard output in a readable form. This is for debugging only and can be used to help understand events and their parameters. Note that it will show only events for which a handler is defined.
+The code here shows a simple script that does nothing but loading a script. The script [misc/dump-events](https://docs.zeek.org/en/current/scripts/policy/misc/dump-events.bro.html) prints the events that Zeek generates out to standard output in a readable form. This is for debugging only and can be used to help understand events and their parameters. Note that it will show only events for which a handler is defined.
 
 A small note needs to be made here because there are some default paths defined by Zeek automatically which make it easier to load many of the scripts that are included with Zeek. The default paths are as follows (based on the installed prefix directory): 
 
@@ -15,8 +15,8 @@ A small note needs to be made here because there are some default paths defined 
   - `<prefix>/share/bro/policy`
   - `<prefix>/share/bro/site`
 
-The most common use case of the load statement is in [local.bro](https://www.zeek.org/sphinx/components/broctl/README.html#site-specific-customization).
-This file is part of Zeek's configuration files and adds further scripts that are not loaded by default. A reference of all scripts that can be loaded is found [here](https://www.zeek.org/sphinx/script-reference/scripts.html).
+The most common use case of the load statement is in [local.bro](https://docs.zeek.org/en/current/components/broctl/README.html#site-specific-customization).
+This file is part of Zeek's configuration files and adds further scripts that are not loaded by default. A reference of all scripts that can be loaded is found [here](https://docs.zeek.org/en/current/script-reference/scripts.html).
 Everything you see there in `base/` is loaded by default, e.g., policies have to be loaded via the load statement.
 
 

--- a/manager/static/examples/basics/loops/while/readme.markdown
+++ b/manager/static/examples/basics/loops/while/readme.markdown
@@ -6,9 +6,9 @@ Loops: While
 
 A "while" loop iterates over a body statement as long as a given condition remains true.
 
-A [break](https://www.zeek.org/sphinx-git/script-reference/statements.html#keyword-break) 
+A [break](https://docs.zeek.org/en/current/script-reference/statements.html#keyword-break) 
 statement can be used at any time to immediately terminate 
 the "while" loop, and a 
-[next](https://www.zeek.org/sphinx-git/script-reference/statements.html#keyword-next) 
+[next](https://docs.zeek.org/en/current/script-reference/statements.html#keyword-next) 
 statement can be used to skip to the next loop iteration.
 

--- a/manager/static/examples/basics/primitive-datatypes/readme.markdown
+++ b/manager/static/examples/basics/primitive-datatypes/readme.markdown
@@ -12,11 +12,11 @@ fixed) with type inference, e.g., `local x = 0` is equivalent to
 `local x: count = 0`. It also implicitly promotes/coerces types in
 certain situations.
 
-The full reference on types in Zeek can be found [here](https://www.zeek.org/sphinx/script-reference/types.html).
+The full reference on types in Zeek can be found [here](https://docs.zeek.org/en/current/script-reference/types.html).
 For now, look through the simple types. Most of the types should be familiar from other programming languages,
 e.g., `bool`, `double`, `int`, `count`, `string`, `pattern` (a regular expression using [flex's syntax](http://westes.github.io/flex/manual/Patterns.html)).
 But Zeek as a network monitoring system introduces also a set of domain-specific types that are explained 
-in the [reference](https://www.zeek.org/sphinx/script-reference/types.html).
+in the [reference](https://docs.zeek.org/en/current/script-reference/types.html).
 Examples are `time`, `interval`, `port`, `addr`, and `subnet`.
 
 These custom Zeek types and the more complex types will be discussed in detailed examples in later lessons. 

--- a/manager/static/examples/basics/variables/readme.markdown
+++ b/manager/static/examples/basics/variables/readme.markdown
@@ -11,7 +11,7 @@ and will be assigned its initial
 value each time the function body is executed. 
 
 The reference on declaring variables, constants, functions etc is found 
-[here](https://www.zeek.org/sphinx/script-reference/statements.html).
+[here](https://docs.zeek.org/en/current/script-reference/statements.html).
 More on types and all things that can be declared will follow in later lessons of this
 tutorial.
 

--- a/manager/static/examples/congrats/readme.markdown
+++ b/manager/static/examples/congrats/readme.markdown
@@ -9,5 +9,5 @@ Welcome in the world of Zeek. We hope you enjoyed this little journey.
 
 Feedback is more than welcome, please write to [info@zeek.org](info@zeek.org).
 
-To find more resources to learn Zeek click [here](https://www.zeek.org/documentation/index.html).
-Or go back to the [Tutorial Index](https://www.zeek.org/documentation/tutorials/index.html).
+To find more resources to learn Zeek visit the [Zeek web site](https://www.zeek.org).
+Or go back to the [Tutorial Index](https://old.zeek.org/documentation/tutorials/index.html).

--- a/manager/static/examples/hello/readme.markdown
+++ b/manager/static/examples/hello/readme.markdown
@@ -22,7 +22,7 @@ and
  
 The first is executed when Zeek is started, the second when Zeek terminates, so we can use these for example
 when no traffic is actually analyzed as we do for our basic examples
-(see [here](https://www.zeek.org/sphinx/scripts/base/bif/event.bif.bro.html) for more on these basic events).
+(see [here](https://docs.zeek.org/en/current/scripts/base/bif/event.bif.bro.html) for more on these basic events).
 In this tutorial we will come back to events in the lesson about [complex data types](http://try.zeek.org/example/events).
 
 Other than that, all this script does is sending warm greetings to new Zeek users by printing to STDOUT.
@@ -32,6 +32,6 @@ Try.Zeek allows you to hide the text if you want to script console to be full wi
 Every example can be run with a pcap file, you can select one below the script area. You can also
 upload your own pcap-examples. Select a pcap and click run again. Below the print-output you will find tabs
 with the familar log-file names. You can click on each row inside a log file and get more details. If Zeek logs are not yet
-familiar to you please go to the documentation on [log files](https://www.zeek.org/sphinx/script-reference/log-files.html).
+familiar to you please go to the documentation on [log files](https://docs.zeek.org/en/current/script-reference/log-files.html).
 
 When you are ready you can just click on next below and start the next example.

--- a/manager/static/examples/intel/intel-1/readme.markdown
+++ b/manager/static/examples/intel/intel-1/readme.markdown
@@ -9,7 +9,7 @@ The Intel Framework provides an interface to feed your own intelligence data int
 "Intelligence data is critical to the process of monitoring for security purposes. There is always data which will be discovered through the incident response process and data which is shared through private communities. The goals of Zeek's Intelligence Framework are to consume that data, make it available for matching, and provide infrastructure around improving performance, memory utilization, and generally making all of this easier." 
 
 Find the whole documentation on the Intelligence Framework on 
-our [website](https://www.zeek.org/sphinx/frameworks/intel.html). 
+our [website](https://docs.zeek.org/en/current/frameworks/intel.html). 
 You will also find details on input formats etc.
 
 Run the example given. Have a look at the extra file "intel-1.dat".

--- a/manager/static/examples/logs/filter-logs/readme.markdown
+++ b/manager/static/examples/logs/filter-logs/readme.markdown
@@ -13,7 +13,7 @@ For this we go back to the factorial module. The goal now is to split the loggin
 one log-file that are divisible evenly by 5, the others to a second log-file. 
 Which record is sent to which log-file is decided dynamically based on the 
 modulo function. Find more details on dynamically determining log paths 
-[here](https://www.zeek.org/sphinx/frameworks/logging.html#determine-log-path-dynamically).
+[here](https://docs.zeek.org/en/current/frameworks/logging.html#determine-log-path-dynamically).
 
 Now run the code example. You see that there are now two log-files, one called `num` and `factorial_num`.
 Lets look at the code. In the module *factorial.bro* we add a new function, the `path_func` we

--- a/manager/static/examples/logs/rename-logs/readme.markdown
+++ b/manager/static/examples/logs/rename-logs/readme.markdown
@@ -10,8 +10,8 @@ A stream has one or more filters attached to it (a stream without any filters wi
 When a stream is created, it automatically gets a default filter attached to it. 
 This default filter can be removed or replaced, or other filters can be added to the stream. 
 This is accomplished by using either the 
-[Log::add_filter](https://www.zeek.org/sphinx/scripts/base/frameworks/logging/main.bro.html#id-Log::add_filter) 
-or [Log::remove_filter](https://www.zeek.org/sphinx/scripts/base/frameworks/logging/main.bro.html#id-Log::remove_filter) 
+[Log::add_filter](https://docs.zeek.org/en/current/scripts/base/frameworks/logging/main.bro.html#id-Log::add_filter) 
+or [Log::remove_filter](https://docs.zeek.org/en/current/scripts/base/frameworks/logging/main.bro.html#id-Log::remove_filter) 
 function. The default filter writes all fields to the logfile that carry the `&log` attribute.
 In this tutorial we will show you how to use filters to do such tasks as rename a log file, 
 split the output into multiple files, control which records are written, and set a custom rotation interval.
@@ -21,7 +21,7 @@ filter with a new filter that specifies a value for the “path” field. We'll 
 
 Step by step:
 First the function *get_filter* assoziates the new filter *f* with the logging stream of the
-[connection analyzer log strteam](https://www.zeek.org/sphinx/scripts/base/protocols/conn/).
+[connection analyzer log strteam](https://docs.zeek.org/en/current/scripts/base/protocols/conn/).
 After that the new name `myconn` is set. This new filter has to be added to the logging stream.
 
 

--- a/manager/static/examples/modules/log-factorial/readme.markdown
+++ b/manager/static/examples/modules/log-factorial/readme.markdown
@@ -6,12 +6,12 @@ Writing a Module: Logging
 
 Often a new module creates new data that you may want to collect in a new log file, too.
 Manipulating Logs in Zeek is a useful tool and is more than just adding more log-files or fields.
-We use the case of the factorial module to introduce you to the [logging framework](https://www.zeek.org/sphinx/frameworks/logging.html)
+We use the case of the factorial module to introduce you to the [logging framework](https://docs.zeek.org/en/current/frameworks/logging.html)
 
 Again, we first look into factorial.bro.
 In the export section you find a new line that uses `redef` to add a new value named `LOG`
 to the `Log::ID` enumerable. This enumerable is part of Zeek's logging framework. You can find details
-[here](https://www.zeek.org/sphinx-git/scripts/base/frameworks/logging/main.bro.html).
+[here](https://docs.zeek.org/en/current/scripts/base/frameworks/logging/main.bro.html).
 
 The next step is to create a record that contains the columns of the future log file. The record
 is named `Info`. We create two columns named `num` and `factorial_num`. `num` is there to list the current value
@@ -20,15 +20,15 @@ tells Zeek that a field of the given name has to be added to the logging stream.
 
 During this tutorial you have already seen some attributes. Attributes are used to add certain properties to functions and
 variables. For example the `&redef` attribute allows to redefine a global constant or extend a type. `&optional` allows a 
-value in a record field to be missing. The list of all attributes is found [here](https://www.zeek.org/sphinx/script-reference/attributes.html?highlight=attributes).
+value in a record field to be missing. The list of all attributes is found [here](https://docs.zeek.org/en/current/script-reference/attributes.html?highlight=attributes).
 
 Now please switch to the file main.bro. At the beginning of our script we need to create the new logging
-stream. [Log::create\_stream](https://www.zeek.org/sphinx/scripts/base/frameworks/logging/main.bro.html?highlight=log%3A%3Acreate_stream#id-Log::create_stream) does exactly this. 
+stream. [Log::create\_stream](https://docs.zeek.org/en/current/scripts/base/frameworks/logging/main.bro.html?highlight=log%3A%3Acreate_stream#id-Log::create_stream) does exactly this. 
 The necessary parameters are of course the module's `LOG` value, and the record that holds the logging fields. 
 The variable `$path` tells Zeek how it should name the new log-file. Note that the Log stream needs to be initialized within the bro\_init event.
 
 The next step looks very similar to the one before, but instead of printing the results to Stdout we now 
-write to the new log, using the [Log::write](https://www.zeek.org/sphinx/scripts/base/frameworks/logging/main.bro.html?highlight=log%3A%3Awrite#id-Log::write) function.
+write to the new log, using the [Log::write](https://docs.zeek.org/en/current/scripts/base/frameworks/logging/main.bro.html?highlight=log%3A%3Awrite#id-Log::write) function.
 
 One more note on writing to logs: In this example we wrote all results within bro\_done, in a real world example this
 is usually done inside an event handler that has to do with the log-file.

--- a/manager/static/examples/modules/module/readme.markdown
+++ b/manager/static/examples/modules/module/readme.markdown
@@ -1,5 +1,5 @@
 title: Writing a Module
-pcaps: 
+pcaps:
 
 Writing a Module
 =====================
@@ -10,17 +10,17 @@ A module can be a file or a bundle of files, a package. See below on this page.
 
 It is important to know
 that you cannot write new protocol events, you can only react in a different way on an event that is already implemented
-in Zeek. Extending Zeek with [new analyzers](https://www.zeek.org/development/howtos/dpd.html) and  
-creating new events is a topic that is beyond the scope of Try.Zeek. 
+in Zeek. Extending Zeek with [new analyzers](https://old.zeek.org/development/howtos/dpd.html) and
+creating new events is a topic that is beyond the scope of Try.Zeek.
 Usually a module reacts on already existing internal events coming from the Zeek event engine.
 Events that are not working on traffic can created within a Zeek script, though.
 
 Before you dive into Zeek Modules we would like to point you on the
-[Zeek Scripting Conventions](https://www.zeek.org/development/howtos/script-conventions.html).
+[Zeek Scripting Conventions](https://old.zeek.org/development/howtos/script-conventions.html).
 Apart from naming conventions the Zeek scripts sets use a convention for file-names and
-the setup of Modules. We've already talked about 
+the setup of Modules. We've already talked about
 [loading scripts](http://try.zeek.org/examples/loading). If you have a look into the
-[Zeek Script Packages](https://www.zeek.org/sphinx/script-reference/packages.html)
+[Zeek Script Packages](https://docs.zeek.org/en/current/script-reference/packages.html)
 you will find that each Module consists at least of two files, `__load__.bro` and
 `main.bro`. The first one should list all files that are part of the module (also `main.bro`)
 The directory name in which all those files are collected gives the name to the module.

--- a/manager/static/examples/new-notice/readme.markdown
+++ b/manager/static/examples/new-notice/readme.markdown
@@ -7,7 +7,7 @@ Raising a Notice
 One of the easiest ways to customize Zeek is writing a local notice policy.
 Apart from looking into log files you can ask Zeek to send you emails, either for a 
 certain situation or aggregated summary emails about warnings etc.
-This feature is given through the [Notice Framework](https://www.zeek.org/sphinx/frameworks/notice.html).
+This feature is given through the [Notice Framework](https://docs.zeek.org/en/current/frameworks/notice.html).
 
 In this lesson we start by creating a new notice. In Try.Zeek the notice can only be made into a log file.
 It can't send an email. Please run the code example and have a look at the new log-file.

--- a/manager/static/examples/sumstats/sumstats1/readme.markdown
+++ b/manager/static/examples/sumstats/sumstats1/readme.markdown
@@ -12,7 +12,7 @@ a scanner activity. To many users this framework appears difficult to use. This 
 is meant to change that.
 
 Alongside this tutorial you can read the 
-[documentation](https://www.zeek.org/sphinx/frameworks/sumstats.html) 
+[documentation](https://docs.zeek.org/en/current/frameworks/sumstats.html) 
 explaining the terminology used for the Sumstats framework. This tutorial follows (in parts)
 the live tutorial Seth Hall gave at BroCon 2014, which is available as Youtube 
 [video](https://youtu.be/9YsenekNaSI)
@@ -37,9 +37,9 @@ something with it. The reducer gets a variable name, r1 in this case, is attache
 dns.lookup and also needs at least one reducing function that is applied on the stream.
 In this example the method used is "UNIQUE".
 More than one calculation method can be applied, they are all listed in the 
-[sumstats reference](https://www.zeek.org/sphinx/scripts/base/frameworks/sumstats/main.bro.html#type-SumStats::Calculation).
+[sumstats reference](https://docs.zeek.org/en/current/scripts/base/frameworks/sumstats/main.bro.html#type-SumStats::Calculation).
 There can also be more than one reducer, an example for this is explained in the documentation for
-[MIME type statistics](https://www.zeek.org/sphinx/mimestats/index.html).
+[MIME type statistics](https://docs.zeek.org/en/current/mimestats/index.html).
 
 The third step is to link the reducer to a SumStats to finally do something with it.
 The SumStats also gets a name to reference later. An epoch is assigned, in this case 6 hours. 
@@ -54,4 +54,4 @@ Comment out the two lines within the epoch\_result and directly print result. Yo
 all fields available to print out.
 
 Exercise: Use the heuristic version of the unique calculation, HLL\_UNIQUE, you find it 
-in the [documentation](https://www.zeek.org/sphinx/scripts/base/frameworks/sumstats/main.bro.html#type-SumStats::Calculation). Then take a sample of size 5. For the solution go to the next page.
+in the [documentation](https://docs.zeek.org/en/current/scripts/base/frameworks/sumstats/main.bro.html#type-SumStats::Calculation). Then take a sample of size 5. For the solution go to the next page.

--- a/manager/static/examples/sumstats/sumstats2/readme.markdown
+++ b/manager/static/examples/sumstats/sumstats2/readme.markdown
@@ -16,5 +16,5 @@ Next Exercise
 Sumstats becomes especially useful if used with thresholds. Write a sumstats script 
 that counts the DNS lookups and writes a notice if a host does more than 10 DNS lookups.
 Have a look at the available SumStat 
-[functions](https://www.zeek.org/sphinx/scripts/base/frameworks/sumstats/main.bro.html?highlight=sumstats#type-SumStats::SumStat)
+[functions](https://docs.zeek.org/en/current/scripts/base/frameworks/sumstats/main.bro.html?highlight=sumstats#type-SumStats::SumStat)
 to find out how to work with thresholds.

--- a/manager/static/examples/sumstats/sumstats3/readme.markdown
+++ b/manager/static/examples/sumstats/sumstats3/readme.markdown
@@ -12,6 +12,6 @@ In order to do this we need to evaluate the threshold first, once it is crossed 
 Within this platform we can only write it to the notice.log but in reality it can of course be sent as
 an email to warn the security admin about suspicious behavior.
 
-A more advanced sumstats example is the script [scan.bro](https://www.zeek.org/sphinx/_downloads/scan.bro).
+A more advanced sumstats example is the script [scan.bro](https://docs.zeek.org/en/current/_downloads/scan.bro).
 This script uses more than one reducer and looks for scanning of ports and IP addresses at the same time.
 


### PR DESCRIPTION
The documentation links on try.zeek are currently broken after the web site move since we hadn't updated them yet to point to RTD. This PR makes that changes (plus, a couple of links changed to old.zeek.org for now where we don't have equivalents on the new server yet).