### PR TITLE
docker-compose: Bump gunicorn timeout to 20 seconds

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
 
   api:
     build: manager
-    command: gunicorn -w 4 -b 0.0.0.0 app:app --log-file - --max-requests 500 --timeout 10
+    command: gunicorn -w 4 -b 0.0.0.0 app:app --log-file - --max-requests 500 --timeout 20
     restart: always
     depends_on:
       - redis


### PR DESCRIPTION
When a Zeek script is running longer than 10 seconds gunicorn times out
the POST /run request and the response the UI gets is HTTP 502 Bad Gateway.
There's no indication in the UI that this occurred and it looks like
execution is just hanging.

The worker terminates script execution properly after 15(+2) seconds
in runbro using the timeout command. Bump the gunicorn timeout to 20 seconds
to cover that plus a bit of wiggle room.