### PR TITLE
caddy: ensure auto_https works for any domain

### DIFF
--- a/containers/caddy/Caddyfile.notls
+++ b/containers/caddy/Caddyfile.notls
@@ -1,16 +1,16 @@
 {
-    auto_https off
+	auto_https off
 }
 
-servers :80 {
+*:80 {
 	reverse_proxy {
-	    to api:8000
-        }
+		to api:8000
+	}
 	header -Server
 
 	log {
-	    output stdout
-	    format console
+		output stdout
+		format console
 	}
 	encode gzip
 }

--- a/containers/caddy/Caddyfile.tls
+++ b/containers/caddy/Caddyfile.tls
@@ -1,21 +1,22 @@
 {
-    on_demand_tls {
-        interval 1d
-        burst 5
-    }
+	on_demand_tls {
+		interval 1d
+		burst 5
+	}
 }
-servers :443 {
-    tls {
-        on_demand
-    }
-    reverse_proxy {
-        to api:8000
-    }
-    header -Server
 
-    log {
-        output stdout
-        format console
-    }
-    encode gzip
+*:443 {
+	tls {
+		on_demand
+	}
+	reverse_proxy {
+		to api:8000
+	}
+	header -Server
+
+	log {
+		output stdout
+		format console
+	}
+	encode gzip
 }


### PR DESCRIPTION
Attempting to deploy the latest branch on try.zeek.org it was
found that certificates were not automatically provisioned.

Add back a `*` to fix and remove superflous "servers".

And run caddy fmt to squelch a warning during startup.
