### PR TITLE
drop lock for docker as the library should be thread-safe

### DIFF
--- a/manager/worker.py
+++ b/manager/worker.py
@@ -136,33 +136,32 @@ def _run_code_docker(sources, pcap, version, work_dir):
     #docker run -v /brostuff/tmpWh0k1x:/brostuff/ -n --rm -t -i  bro_worker /bro/bin/bro /brostuff/code.bro
 
     print("Connecting to docker....")
-    with r.lock("docker", 5) as lck:
-        c = docker.Client()
+    c = docker.Client()
 
-        print("Creating Bro %s container.." % version)
-        host_config = docker.utils.create_host_config(
-            binds=binds,
-            dns=["127.0.0.1"],
-            mem_limit="128m",
-            network_mode="none",
-            read_only=True,
-        )
-        container = c.create_container('zeekurity/zeek:' + version,
-            working_dir=work_dir,
-            command=runbro_path,
-            host_config=host_config,
-            volumes=[work_dir],
-        )
-        print("Starting container..")
-        try:
-            c.start(container)
+    print("Creating Bro %s container.." % version)
+    host_config = docker.utils.create_host_config(
+        binds=binds,
+        dns=["127.0.0.1"],
+        mem_limit="128m",
+        network_mode="none",
+        read_only=True,
+    )
+    container = c.create_container('zeekurity/zeek:' + version,
+        working_dir=work_dir,
+        command=runbro_path,
+        host_config=host_config,
+        volumes=[work_dir],
+    )
+    print("Starting container..")
+    try:
+        c.start(container)
 
-            print("Waiting..")
-            c.wait(container)
+        print("Waiting..")
+        c.wait(container)
 
-        finally:
-            print("Removing Container")
-            c.remove_container(container)
+    finally:
+        print("Removing Container")
+        c.remove_container(container)
 
     files = {}
     for f in os.listdir(work_dir):


### PR DESCRIPTION
Remove the lock around docker calls because:
 * the lock shouldn't be needed
 * we are seeing tracebacks when the lock times out