### PR TITLE
Automatic Zeek image pulling

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,9 +22,9 @@ services:
     networks:
       - backend
 
-  version-update:
+  version-updater:
     build: manager
-    command: python3 version.py -i 300
+    command: python3 version.py -i 4020
     init: true
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,18 @@ services:
     networks:
       - backend
 
+  version-update:
+    build: manager
+    command: python3 version.py -i 300
+    init: true
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    restart: always
+    depends_on:
+      - redis
+    networks:
+      - backend
+
   api:
     build: manager
     command: gunicorn -w 4 -b 0.0.0.0 app:app --log-file - --max-requests 500 --timeout 20

--- a/manager/app.py
+++ b/manager/app.py
@@ -57,7 +57,7 @@ def run():
 @app.route("/run_simple", methods=['GET', 'POST'])
 def run_simple():
     stdin = request.args.get("code") or request.form.get("code") or 'print "Huh?";'
-    version = request.args.get("version") or request.form.get("version") or backend.BRO_VERSION
+    version = request.args.get("version") or request.form.get("version")
 
     files = backend.run_code_simple(stdin, version=version)
     return cors_jsonify(files=files)
@@ -81,7 +81,8 @@ def files_json(job):
 
 @app.route("/versions.json")
 def versions():
-    return cors_jsonify(versions=backend.BRO_VERSIONS, default=backend.BRO_VERSION)
+    default_version, versions = backend.zeek_versions_from_redis()
+    return cors_jsonify(versions=versions, default=default_version)
 
 @app.route("/pcap/upload/<checksum>", methods=['OPTIONS'])
 def pcap_upload_options_for_cors(checksum):

--- a/manager/common.py
+++ b/manager/common.py
@@ -1,8 +1,11 @@
 import hashlib
 import json
+import os
+
 import redis
 import rq
 
+REDIS_HOST = os.environ.get("REDIS_HOST", "redis")
 
 def get_cache_key(sources, pcap, version):
     key = [sources, pcap, version]
@@ -12,12 +15,12 @@ def get_cache_key(sources, pcap, version):
     return cache_key
 
 
-def get_redis():
-    return redis.StrictRedis("redis", charset="utf-8", decode_responses=True)
+def get_redis() -> redis.StrictRedis:
+    return redis.StrictRedis(REDIS_HOST, charset="utf-8", decode_responses=True)
 
 
 def get_redis_raw():
-    return redis.Redis("redis")
+    return redis.Redis(REDIS_HOST)
 
 
 def get_rq():

--- a/manager/version.py
+++ b/manager/version.py
@@ -1,0 +1,129 @@
+"""
+Zeek version helper.
+
+All available Zeek versions are stored within the zeek:versions set
+in Redis. This script polls the Docker Hub API once in a while and
+fetches all new tags using docker-py.
+"""
+import argparse
+import logging
+import re
+import time
+import typing
+
+import docker
+import requests
+
+from common import get_redis
+
+logger = logging.getLogger(__name__)
+
+NAMESPACE = "zeek"
+REPO = "zeek"
+TAGS_URL = f"https://hub.docker.com/v2/namespaces/{NAMESPACE}/repositories/{REPO}/tags"
+
+REDIS_VERSION_KEY = "zeek:versions"
+
+
+def is_acceptable_zeek_version(version: str):
+    """
+    For now, just the three digit version tags, avoiding the 6.0, lts
+    and amd64 / arm64 architecture ones.
+    """
+    return re.match(r"^[0-9]+\.[0-9]+\.[0-9]+$", version) is not None
+
+
+def zeek_versions_from_redis() -> typing.Tuple[str, list[str]]:
+    """
+    Return versions found in Redis as tuple (default, all).
+    """
+    redis = get_redis()
+    versions = sorted(redis.smembers(REDIS_VERSION_KEY))
+    default = versions[-1]
+    if versions == "master" and len(versions) > 1:
+        return versions[-2]
+
+    return default, versions
+
+
+def pull_new_tags():
+    """
+    Fetch all tags from Docker Hub and pull those we do no know about yet.
+
+    https://docs.docker.com/docker-hub/api/latest/#tag/repositories/paths/%7E1v2%7E1namespaces%7E1%7Bnamespace%7D%7E1repositories%7E1%7Brepository%7D%7E1tags/get
+    """
+    response = requests.get(TAGS_URL, timeout=30)
+    response.raise_for_status()
+
+    redis = get_redis()
+    docker_client = docker.Client()
+
+    _, known_versions = zeek_versions_from_redis()
+
+    logger.info("known_versions: %s", known_versions)
+    for result in response.json()["results"]:
+        version = result["name"]
+
+        if not is_acceptable_zeek_version(version):
+            logger.debug("Ignoring tag %r", version)
+            continue
+
+        if version in known_versions:
+            logger.debug("Ignoring known tag %r", version)
+            continue
+
+        logger.info("Pulling new image %s", version)
+        docker_client.pull(f"{NAMESPACE}/{REPO}", tag=version)
+
+        # Update Redis
+        redis.sadd(REDIS_VERSION_KEY, version)
+
+
+def sync_docker_versions_to_redis():
+    """
+    List locally available container images and store their tags in Redis.
+    """
+    redis = get_redis()
+    docker_client = docker.Client()
+
+    images = docker_client.images(name="zeek/zeek")
+    tags = []
+    for i in images:
+        tags.extend(i["RepoTags"])
+
+    versions = [t.replace("zeek/zeek:", "") for t in tags if "_" not in t]
+    versions = [v for v in versions if is_acceptable_zeek_version(v)]
+
+    redis.sadd(REDIS_VERSION_KEY, *versions)
+
+    # Also fetch all versions from Redis and remove those
+    # not available to Docker anymore.
+    _, redis_versions = zeek_versions_from_redis()
+    for rv in redis_versions:
+        if rv not in versions:
+            logger.info("Deleting %r from Redis", rv)
+            redis.srem(REDIS_VERSION_KEY, rv)
+
+
+def main():
+    """
+    Entry point.
+    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-i", "--interval", type=int, default=5 * 60)
+    parser.add_argument("-l", "--log-level", type=str, default="info")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=getattr(logging, args.log_level.upper()))
+    while True:
+        sync_docker_versions_to_redis()
+        pull_new_tags()
+        try:
+            time.sleep(args.interval)
+        except KeyboardInterrupt:
+            logger.info("Interrupt")
+            break
+
+
+if __name__ == "__main__":
+    main()

--- a/tryzeek.service
+++ b/tryzeek.service
@@ -7,7 +7,6 @@ Requires=docker.service
 TimeoutStartSec=0
 #ExecStartPre=-/usr/bin/docker kill trybro
 #ExecStartPre=-/usr/bin/docker rm trybro
-ExecStartPre=/usr/bin/docker pull zeek/zeek:6.0.0
 WorkingDirectory=/root/try-zeek
 RemainAfterExit=yes
 Type=oneshot


### PR DESCRIPTION
Add a side-car container that regularly polls the Docker Hub API and pulls any new images. Further, store available versions in Redis so the API has direct access without the need to restart the service.


@JustinAzoff , does that look reasonable, or would you prefer another route?