### PR TITLE
backend: Use uuid4 for job_id

### DIFF
--- a/manager/backend.py
+++ b/manager/backend.py
@@ -2,6 +2,7 @@ import time
 import json
 import hashlib
 import traceback
+import uuid
 
 import redis
 
@@ -26,8 +27,7 @@ def wait_for_result(r):
     return r.result
 
 def get_job_id():
-    bro_id = str(r.incr("trybro:id"))
-    return bro_id
+    return uuid.uuid4().hex
 
 def run_code(sources, pcap, version=None):
     """Try to find a cached result for this submission

--- a/manager/web-ui/src/actions.js
+++ b/manager/web-ui/src/actions.js
@@ -349,7 +349,7 @@ export function loadSaved(job, autorun) {
 
 export function handleLocationChange(dispatch, location, initial=false) {
     console.log('Location is now', location);
-    var match = /\/(?:trybro|tryzeek)\/saved\/(\d+)/.exec(location.pathname);
+    var match = /\/(?:trybro|tryzeek)\/saved\/([0-9a-f]+)/.exec(location.pathname);
     if (match) {
         var job = match[1];
         return dispatch(loadSaved(job, initial));


### PR DESCRIPTION
The previously used sequential job id allowed to easily scrape for submissions from other people. Avoid this information disclosure vector by switching to uuid4 based job ids.

This was reported by Aaron Scantlin, thanks.