### PR TITLE
Formater support using zeekscript

### DIFF
--- a/manager/app.py
+++ b/manager/app.py
@@ -119,11 +119,13 @@ def format():
     for src in sources:
         # If anything goes wrong, just leave it unchanged.
         try:
-            src['content'] = fmt(src['content'])
+            src['content'], error = fmt(src['content'])
+            if error:
+                errors[src['name']] = [error]
         except Exception as err:
             pass
 
-    return cors_jsonify(sources=sources)
+    return cors_jsonify(sources=sources, errors=errors)
 
 def md5(s):
     m = hashlib.md5()

--- a/manager/app.py
+++ b/manager/app.py
@@ -6,6 +6,7 @@ import os
 
 import backend
 import metrics
+from format import fmt
 
 class FlaskStaticCors(Flask):
     def send_static_file(self, filename):
@@ -111,6 +112,18 @@ def pcap_list():
     paths = glob.glob(os.path.join(app.static_folder, "pcaps/*.pcap"))
     pcaps = list(map(os.path.basename, paths))
     return cors_jsonify(available=pcaps)
+
+@app.route("/format", methods=['POST'])
+def format():
+    sources = request.json.get('sources', [])
+    for src in sources:
+        # If anything goes wrong, just leave it unchanged.
+        try:
+            src['content'] = fmt(src['content'])
+        except Exception as err:
+            pass
+
+    return cors_jsonify(sources=sources)
 
 def md5(s):
     m = hashlib.md5()

--- a/manager/format.py
+++ b/manager/format.py
@@ -1,12 +1,35 @@
 import io
+import re
+
 import zeekscript
+
+
+ERROR_REGEX = r'line (\d+), col (\d+)'
+
+def parse_error(error):
+    # This is a tuple of... (string, some number, actual error)
+    txt = error[2]
+    # 'cannot parse line 0, col 0: "function() {"'
+
+    match = re.search(ERROR_REGEX, txt)
+    if not match:
+        return None
+
+    line = int(match.group(1))
+    col = int(match.group(2))
+
+    return {
+        'row': line,
+        'column': col,
+        'type': "error",
+        'text': txt,
+    }
 
 def fmt(txt):
     s = zeekscript.Script(io.StringIO(txt))
     s.parse()
     if s.has_error():
-        print("Error!")
-        return txt
+        return txt, parse_error(s.get_error())
     buf = io.BytesIO()
     s.format(buf)
-    return buf.getvalue().decode()
+    return buf.getvalue().decode(), None

--- a/manager/format.py
+++ b/manager/format.py
@@ -1,0 +1,12 @@
+import io
+import zeekscript
+
+def fmt(txt):
+    s = zeekscript.Script(io.StringIO(txt))
+    s.parse()
+    if s.has_error():
+        print("Error!")
+        return txt
+    buf = io.BytesIO()
+    s.format(buf)
+    return buf.getvalue().decode()

--- a/manager/requirements.txt
+++ b/manager/requirements.txt
@@ -32,3 +32,5 @@ websocket-client==1.4.2
 Werkzeug==3.0.1
 wrapt==1.14.1
 zipp==3.10.0
+tree-sitter==0.21.2
+zeekscript==1.2.8

--- a/manager/test_format.py
+++ b/manager/test_format.py
@@ -1,0 +1,19 @@
+import unittest
+from format import fmt
+
+class TestFormat(unittest.TestCase):
+
+    def test_cases(self):
+        cases = [
+            ('event zeek_init(){}', None),
+            ('event zeek_init(){', {'row': 0, 'column': 18, 'type': 'error', 'text': 'missing grammar node "}" on line 0, col 18'}),
+            ('function foo(){}', None),
+            ('function foo({}', {'row': 0, 'column': 13, 'type': 'error', 'text': 'missing grammar node ")" on line 0, col 13'}),
+        ]
+        for case, expected in cases:
+            with self.subTest(txt=case):
+                _, error = fmt(case)
+                self.assertEqual(error, expected)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/manager/web-ui/src/App.js
+++ b/manager/web-ui/src/App.js
@@ -412,7 +412,7 @@ export class App extends Component {
                         <label>
                             <input type="file" ref="file" onChange={this.fileChanged} />
                         </label>
-                        <Button bsStyle="info" onClick={this.formatCode}> Format </Button>
+                        <Button variant="secondary" onClick={this.formatCode}>Format</Button>
                         { ' ' }
                         <RunButton status={exec.status} pcap={pcap} onClick={this.runCode} />
                         </Col>

--- a/manager/web-ui/src/App.js
+++ b/manager/web-ui/src/App.js
@@ -14,6 +14,7 @@ import { fetchExamples, hideExample, showExample } from './actions';
 import { codeAddFile, codeSelectFile, codeRenameFile, codeEditFile } from './actions';
 import { execReset, execSubmit } from './actions';
 import { fetchPcaps, pcapSelected, pcapFileChanged } from './actions';
+import { formatSubmit } from './actions';
 
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome'
 import { solid, regular } from '@fortawesome/fontawesome-svg-core/import.macro' // <-- import styles to be used
@@ -359,6 +360,9 @@ export class App extends Component {
     runCode = () => {
         this.props.dispatch(execSubmit());
     }
+    formatCode = () => {
+        this.props.dispatch(formatSubmit());
+    }
     fileChanged = () => {
         var f = this.refs.file.files[0];
         this.props.dispatch(pcapFileChanged(f));
@@ -408,6 +412,8 @@ export class App extends Component {
                         <label>
                             <input type="file" ref="file" onChange={this.fileChanged} />
                         </label>
+                        <Button bsStyle="info" onClick={this.formatCode}> Format </Button>
+                        { ' ' }
                         <RunButton status={exec.status} pcap={pcap} onClick={this.runCode} />
                         </Col>
                     </Row>

--- a/manager/web-ui/src/actions.js
+++ b/manager/web-ui/src/actions.js
@@ -157,6 +157,8 @@ export const EXEC_FETCHED_FILES = 'EXEC_FETCHED_FILES'
 
 export const EXEC_RESET = 'EXEC_RESET'
 
+export const EXEC_SET_ERRORS = 'EXEC_SET_ERRORS';
+
 export function execReset(){
     return {
         type: EXEC_RESET
@@ -275,6 +277,13 @@ export function execComplete(response) {
     }
 }
 
+export function setExecErrors(errors) {
+    return {
+        type: EXEC_SET_ERRORS,
+        errors
+    }
+}
+
 export const PCAP_FETCHING = 'PCAP_FETCHING'
 export const PCAP_FETCHED = 'PCAP_FETCHED'
 export const PCAP_SELECTED = 'PCAP_SELECTED'
@@ -363,6 +372,7 @@ export function formatSubmit() {
             .then(response => response.json())
             .then(json => {
                 dispatch(setCode(json.sources));
+                dispatch(setExecErrors(json.errors));
             });
     };
 }

--- a/manager/web-ui/src/actions.js
+++ b/manager/web-ui/src/actions.js
@@ -345,6 +345,27 @@ export function loadSaved(job, autorun) {
     }
 }
 
+export function formatSubmit() {
+    return (dispatch, getState) => {
+        const state = getState();
+        const sources = state.code.sources;
+        var opts =  {
+            method: 'post',
+            headers: {
+                'Accept': 'application/json',
+                'Content-Type': 'application/json'
+            },
+            body: JSON.stringify({
+                sources: sources,
+            })
+        };
+        return fetch(`${API_HOST}/format`, opts)
+            .then(response => response.json())
+            .then(json => {
+                dispatch(setCode(json.sources));
+            });
+    };
+}
 
 
 export function handleLocationChange(dispatch, location, initial=false) {

--- a/manager/web-ui/src/reducers.js
+++ b/manager/web-ui/src/reducers.js
@@ -104,12 +104,13 @@ function examples(state = initialExampleState, action) {
 }
 
 function code(state = initialCodeState, action) {
+  console.log(state, action);
   switch (action.type) {
   case CODE_SET:
     return Object.assign({}, state, {
       sources: action.sources,
       current: action.sources[0].name,
-      newCounter: 1
+      newCounter: action.sources.length
     });
   case CODE_ADD_FILE:
     var new_filename = `new-${state.newCounter}.zeek`;

--- a/manager/web-ui/src/reducers.js
+++ b/manager/web-ui/src/reducers.js
@@ -2,7 +2,7 @@ import { combineReducers } from 'redux';
 import { VERSIONS_FETCHING, VERSIONS_FETCHED, VERSIONS_SET } from './actions';
 import { EXAMPLES_FETCHING, EXAMPLES_FETCHED, EXAMPLE_SELECTED, EXAMPLE_HIDE, EXAMPLE_SHOW } from './actions';
 import { CODE_SET, CODE_ADD_FILE, CODE_SELECT_FILE, CODE_RENAME_FILE, CODE_EDIT_FILE } from './actions';
-import { EXEC_RUNNING, EXEC_COMPLETE, EXEC_FETCHING_FILES, EXEC_FETCHED_FILES, EXEC_RESET } from './actions';
+import { EXEC_RUNNING, EXEC_COMPLETE, EXEC_FETCHING_FILES, EXEC_FETCHED_FILES, EXEC_RESET, EXEC_SET_ERRORS } from './actions';
 import { PCAP_FETCHING, PCAP_FETCHED, PCAP_SELECTED, PCAP_FILE_CHANGED, PCAP_UPLOAD_PROGRESS, PCAP_UPLOADED } from './actions';
 import { parse_errors } from './broutil';
 
@@ -189,6 +189,10 @@ function exec(state = initialExecState, action) {
             files: files,
             stderr: stderr,
             errors: parse_errors(stderr)
+        });
+    case EXEC_SET_ERRORS:
+        return Object.assign({}, state, {
+        errors: action.errors
         });
     default:
         return state;


### PR DESCRIPTION
This adds a new api endpoint /format that uses zeekscript to format the source files and additionaly return any parser errors to the UI.