### PR TITLE
Upgrade containers to debian bookworm

### DIFF
--- a/manager/Dockerfile
+++ b/manager/Dockerfile
@@ -9,7 +9,7 @@ RUN cd web-ui && npm install
 ADD web-ui web-ui
 RUN make -C web-ui
 
-FROM      debian:bullseye-slim
+FROM      debian:bookworm-slim
 MAINTAINER Justin Azoff <justin.azoff@gmail.com>
 
 RUN apt-get update && \
@@ -21,7 +21,7 @@ RUN apt-get update && \
 RUN mkdir /brostuff
 
 ADD requirements.txt requirements.txt
-RUN pip3 install -r requirements.txt
+RUN pip3 install --break-system-packages -r requirements.txt
 
 ADD . /src
 WORKDIR /src

--- a/manager/Dockerfile
+++ b/manager/Dockerfile
@@ -2,7 +2,7 @@
 #
 # VERSION               0.3
 
-FROM node AS web-builder
+FROM node:22.12 AS web-builder
 ADD web-ui/package.json web-ui/
 ADD web-ui/package-lock.json web-ui/
 RUN cd web-ui && npm install

--- a/manager/Dockerfile
+++ b/manager/Dockerfile
@@ -2,15 +2,15 @@
 #
 # VERSION               0.3
 
-FROM node as web-builder
+FROM node AS web-builder
 ADD web-ui/package.json web-ui/
 ADD web-ui/package-lock.json web-ui/
 RUN cd web-ui && npm install
 ADD web-ui web-ui
 RUN make -C web-ui
 
-FROM      debian:bookworm-slim
-MAINTAINER Justin Azoff <justin.azoff@gmail.com>
+FROM  debian:bookworm-slim
+LABEL org.opencontainers.image.authors="Justin Azoff <justin.azoff@gmail.com>"
 
 RUN apt-get update && \
     apt-get dist-upgrade -yq && \


### PR DESCRIPTION
This PR upgrades the base container to Bookworm (debian 12.x), plus fixes a few minor warnings that docker complains about during `build`. I tested it locally and everything seems to be functioning as expected.

The reason behind this upgrade is a bunch of warnings from node/npm when updating to more recent packages, and the lack of the ability to upgrade node/npm on bullseye any further than we have.