### PR TITLE
Fix dependencies for zeek-format support

### DIFF
--- a/manager/requirements.txt
+++ b/manager/requirements.txt
@@ -32,5 +32,4 @@ websocket-client==1.4.2
 Werkzeug==3.0.1
 wrapt==1.14.1
 zipp==3.19.1
-tree-sitter==0.21.2
-zeekscript==1.2.8
+zeekscript==1.2.9


### PR DESCRIPTION
We previously used zeekscript-1.2.8 which did not pin its dependency on tree-sitter which broke as that dependency moved along in an incompatible way. This patch bumps us to a fixed version of zeekscript (the latest). We also drop the dependency on tree-sitter which we never used directly.

This fixes building the compose setup with `docker compose build` for me (on macos with an aarch64 Docker).