### PR TITLE
hello TOC: Remove doubled "Functions" entry

### DIFF
--- a/manager/static/examples/hello/readme.markdown
+++ b/manager/static/examples/hello/readme.markdown
@@ -40,7 +40,6 @@ Basics
 ======
  * [Loading Scripts](#/?example=basics-loading)
  * [Functions](#/?example=basics-functions)
- * [Functions](#/?example=basics-functions)
  * [Variables](#/?example=basics-variables)
  * [Primitive Datatypes](#/?example=basics-primitive-datatypes)
  * [Operators](#/?example=basics-operators)


### PR DESCRIPTION
"Functions" is listed twice (linking to the exact same place) in the TOC displayed on the hello page.