### PR TITLE
Bump the itsdangerous package to 2.2.0, required by Flask 3.1.3

### DIFF
--- a/manager/requirements.txt
+++ b/manager/requirements.txt
@@ -14,7 +14,7 @@ gunicorn==23.0.0
 html5lib==1.1
 idna==3.7
 importlib-metadata==5.0.0
-itsdangerous==2.1.2
+itsdangerous==2.2.0
 Jinja2==3.1.6
 Markdown==3.8.1
 MarkupSafe==2.1.1


### PR DESCRIPTION
This resolves
```
13.49 ERROR: Cannot install -r requirements.txt (line 11) and itsdangerous==2.1.2 because these package versions have conflicting dependencies.
13.49
13.49 The conflict is caused by:
13.49     The user requested itsdangerous==2.1.2
13.49     flask 3.1.3 depends on itsdangerous>=2.2.0
```
Tested on local `docker compose` run.